### PR TITLE
Thread-safety of proxying connection pool

### DIFF
--- a/lib/active_replicas.rb
+++ b/lib/active_replicas.rb
@@ -7,6 +7,7 @@ if defined? ActiveRecord
   version = ActiveRecord::VERSION::MAJOR
 
   if version == 4
+    require 'active_replicas/rails4/helpers'
     require 'active_replicas/rails4/connection_handler'
   else
     raise "Unsupported ActiveRecord version: #{version}"

--- a/lib/active_replicas/proxying_connection_pool.rb
+++ b/lib/active_replicas/proxying_connection_pool.rb
@@ -1,5 +1,6 @@
-require 'monitor'
+require 'active_support/core_ext/module/delegation'
 require 'active_support/hash_with_indifferent_access'
+require 'monitor'
 
 module ActiveReplicas
   # Manages connection pools to the primary and replica databases. Returns

--- a/lib/active_replicas/proxying_connection_pool.rb
+++ b/lib/active_replicas/proxying_connection_pool.rb
@@ -7,35 +7,23 @@ module ActiveReplicas
   #
   # Also hanldes the internal state of switching back and forth from replica
   # to primary connections based on heuristics or overrides.
+  #
+  # NOTE: This proxy instance should be provisioned per-thread and it is *not*
+  #   thread-safe!
   class ProxyingConnectionPool
-    attr_reader :primary_pool, :replica_pools
+    attr_reader :handler
 
-    def initialize(proxy_configuration)
-      @primary_pool = ProxyingConnectionPool.connection_pool_for_spec proxy_configuration[:primary]
-
-      @replica_pools = (proxy_configuration[:replicas] || {}).map do |name, config_spec|
-        [ name, ProxyingConnectionPool.connection_pool_for_spec(config_spec) ]
-      end.to_h
+    # handler - `ProcessLocalConnectionHandler` which created this pool.
+    def initialize(handler)
+      @handler = handler
 
       # Calls to `with_primary` will increment and decrement this.
       @primary_depth = 0
       # Current connection pool.
       @current_pool = nil
-
-      extend MonitorMixin
     end
 
-    # Returns an instance of `ActiveRecord::ConnectionAdapters::ConnectionPool`
-    # configured with the given specification.
-    def self.connection_pool_for_spec(config_spec)
-      @@resolver ||= ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new({})
-
-      # Turns a hash configuration into a `ConnectionSpecification` that can
-      # be passed to a `ConnectionPool`.
-      spec = @@resolver.spec ActiveSupport::HashWithIndifferentAccess.new(config_spec)
-
-      ActiveRecord::ConnectionAdapters::ConnectionPool.new spec
-    end
+    delegate :primary_pool, :replica_pools, to: :handler
 
     # ConnectionPool interface methods
     # ================================
@@ -47,23 +35,19 @@ module ActiveReplicas
       return unless conn
 
       ProxyingConnection.new connection: conn,
-                             is_primary: pool == @primary_pool,
+                             is_primary: pool == primary_pool,
                              proxy:      self
     end
 
     def active_connection?
-      synchronize do
-        all_pools.any? { |pool| pool.active_connection? }
-      end
+      all_pools.any?(&:active_connection?)
     end
 
     def release_connection
-      synchronize do
-        each_pool &:release_connection
+      all_pools.each(&:release_connection)
 
-        @primary_depth = 0
-        @current_pool = nil
-      end
+      @primary_depth = 0
+      @current_pool = nil
     end
 
     def with_connection(&block)
@@ -71,21 +55,15 @@ module ActiveReplicas
     end
 
     def connected?
-      synchronize do
-        current_pool.connected?
-      end
+      current_pool.connected?
     end
 
     def disconnect!
-      synchronize do
-        each_pool &:disconnect!
-      end
+      all_pools.each(&:disconnect!)
     end
 
     def clear_reloadable_connections!
-      synchronize do
-        each_pool &:clear_reloadable_connections!
-      end
+      all_pools.each(&:clear_reloadable_connections!)
     end
 
     def current_pool
@@ -100,17 +78,17 @@ module ActiveReplicas
     # ==============================================
 
     def automatic_reconnect=(new_value)
-      each_pool do |pool|
+      all_pools.each do |pool|
         pool.automatic_reconnect = new_value
       end
     end
 
     def connections
-      @primary_pool.connections
+      primary_pool.connections
     end
 
     def spec
-      @primary_pool.spec
+      primary_pool.spec
     end
 
     # Additional methods
@@ -120,7 +98,7 @@ module ActiveReplicas
       previous_pool = @current_pool
 
       @primary_depth += 1
-      @current_pool = @primary_pool
+      @current_pool = primary_pool
 
       yield connection
     ensure
@@ -136,31 +114,27 @@ module ActiveReplicas
     #
     # NOTE: If this is not already in a `with_primary` block then calling this
     #   will irreversably place the proxying pool in the primary state until
-    #   `clear_active_connections!` is called! If you want to *temporarily*
+    #   `release_connection!` is called! If you want to *temporarily*
     #   use the primary then explicitly do so using `with_primary`.
     def primary_connection
       if @primary_depth == 0
         @primary_depth += 1
-        @current_pool = @primary_pool
+        @current_pool = primary_pool
       end
 
       connection
     end
 
-    # Returns an `Enumerable` over all the pools, primary and replicas, owned
+    # Returns an `Enumerable` over all the pools, primary and replicas, used
     # by this proxying pool.
     def all_pools
-      [ @primary_pool ] + @replica_pools.values
-    end
-
-    def each_pool(&block)
-      all_pools.each &block
+      [primary_pool] + replica_pools.values
     end
 
     def pool_which_owns_connection(object_id)
-      return @primary_pool if @primary_pool.connections.any? { |c| c.object_id == object_id }
+      return primary_pool if primary_pool.connections.any? { |c| c.object_id == object_id }
 
-      @replica_pools.values.each do |pool|
+      replica_pools.values.each do |pool|
         return pool if pool.connections.any? { |c| c.object_id == object_id }
       end
 
@@ -168,20 +142,20 @@ module ActiveReplicas
     end
 
     def primary_pool?(pool)
-      pool == @primary_pool
+      pool == primary_pool
     end
 
     def replica_pool?(pool)
-      @replica_pools.values.include? pool
+      replica_pools.values.include? pool
     end
 
     private
 
     def next_pool
-      replicas = @replica_pools.values
+      replicas = replica_pools.values
 
       if replicas.empty?
-        @primary_pool
+        primary_pool
       else
         replicas.sample
       end

--- a/lib/active_replicas/rails4/connection_handler.rb
+++ b/lib/active_replicas/rails4/connection_handler.rb
@@ -1,4 +1,7 @@
+require 'active_support/core_ext/module/delegation'
 require 'concurrent/map'
+
+require 'active_replicas/rails4/process_local_connection_handler'
 
 module ActiveReplicas
   module Rails4
@@ -37,118 +40,6 @@ module ActiveReplicas
       # current process.
       def retrieve_handler
         @process_to_handler[Process.pid] ||= ProcessLocalConnectionHandler.new(@proxy_configuration)
-      end
-    end
-
-    # Provisioned for each process by `ConnectionHandler`. Each process owns
-    # its own pools of connections to primary and replica databases.
-    # Proxying connection pools are then provisioned for each thread.
-    class ProcessLocalConnectionHandler
-      attr_reader :proxy_configuration
-      attr_reader :primary_pool, :replica_pools
-
-      def initialize(proxy_configuration)
-        @proxy_configuration = proxy_configuration
-
-        @primary_pool = Helpers.connection_pool_for_spec @proxy_configuration[:primary]
-
-        @replica_pools = (@proxy_configuration[:replicas] || {}).map do |name, config_spec|
-          [name, Helpers.connection_pool_for_spec(config_spec)]
-        end.to_h
-
-        # Each thread gets its own `ProxyingConnectionPool`.
-        @reserved_proxies = Concurrent::Map.new
-
-        extend MonitorMixin
-      end
-
-      # Returns a list of *all* the connection pools owned by this handler.
-      def connection_pool_list
-        [@primary_pool] + @replica_pools.values
-      end
-
-      def establish_connection(owner, spec)
-        prefix = '[ActiveReplicas::Rails4::ConnectionHandler#establish_connection]'
-        ActiveRecord::Base.logger&.warn "#{prefix} Ignoring spec for #{owner.inspect}: #{spec.inspect}"
-        ActiveRecord::Base.logger&.info "#{prefix} Called from:\n" + Kernel.caller.first(5).map {|t| "  #{t}" }.join("\n")
-
-        current_proxy
-      end
-
-      def active_connections?
-        connection_pool_list.any?(&:active_connection?)
-      end
-
-      def clear_active_connections!
-        synchronize do
-          connection_pool_list.each(&:release_connection)
-          clear_current_proxy
-        end
-      end
-
-      def clear_reloadable_connections!
-        synchronize do
-          connection_pool_list.each(&:clear_reloadable_connections!)
-          clear_proxies!
-        end
-      end
-
-      def clear_all_connections!
-        synchronize do
-          connection_pool_list.each(&:disconnect!)
-          clear_proxies!
-        end
-      end
-
-      # Cribbed from:
-      #   https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L568
-      def retrieve_connection(klass)
-        pool = retrieve_connection_pool klass
-        raise ConnectionNotEstablished, "No connection pool for #{klass}" unless pool
-        conn = pool.connection
-        raise ConnectionNotEstablished, "No connection for #{klass} in connection pool" unless conn
-        conn
-      end
-
-      def connected?(klass)
-        pool = retrieve_connection_pool klass
-        pool && pool.connected?
-      end
-
-      def remove_connection(owner_klass)
-        if proxy = clear_current_proxy
-          proxy.automatic_reconnect = false
-          proxy.disconnect!
-          proxy.spec.config
-        end
-      end
-
-      def retrieve_connection_pool(klass)
-        current_proxy
-      end
-
-      # Semi-private implementation methdos
-      # ===================================
-
-      # Returns the `ThreadLocalConnectionHandler` for this thread.
-      def current_proxy
-        @reserved_proxies[current_thread_id] || synchronize do
-          @reserved_proxies[current_thread_id] ||= ProxyingConnectionPool.new(self)
-        end
-      end
-
-      # Remove the current reserved `ProxyingConnectionPool` from the pool.
-      def clear_current_proxy
-        @reserved_proxies.delete current_thread_id
-      end
-
-      # Clear all reserved `ProxyingConnectionPool` instances from the pool.
-      def clear_proxies!
-        @reserved_proxies.clear
-      end
-
-      def current_thread_id
-        Thread.current.object_id
       end
     end
   end

--- a/lib/active_replicas/rails4/helpers.rb
+++ b/lib/active_replicas/rails4/helpers.rb
@@ -1,0 +1,21 @@
+require 'active_record/connection_adapters/connection_specification'
+
+module ActiveReplicas
+  module Rails4
+    module Helpers
+      extend self
+
+      # Returns an instance of `ActiveRecord::ConnectionAdapters::ConnectionPool`
+      # configured with the given specification.
+      def self.connection_pool_for_spec(config_spec)
+        @@resolver ||= ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new({})
+
+        # Turns a hash configuration into a `ConnectionSpecification` that can
+        # be passed to a `ConnectionPool`.
+        spec = @@resolver.spec ActiveSupport::HashWithIndifferentAccess.new(config_spec)
+
+        ActiveRecord::ConnectionAdapters::ConnectionPool.new spec
+      end
+    end
+  end
+end

--- a/lib/active_replicas/rails4/process_local_connection_handler.rb
+++ b/lib/active_replicas/rails4/process_local_connection_handler.rb
@@ -1,0 +1,119 @@
+require 'monitor'
+
+require 'active_replicas/rails4/helpers'
+
+module ActiveReplicas
+  module Rails4
+    # Provisioned for each process by `ConnectionHandler`. Each process owns
+    # its own pools of connections to primary and replica databases.
+    # Proxying connection pools are then provisioned for each thread.
+    class ProcessLocalConnectionHandler
+      attr_reader :proxy_configuration
+      attr_reader :primary_pool, :replica_pools
+
+      def initialize(proxy_configuration)
+        @proxy_configuration = proxy_configuration
+
+        @primary_pool = Helpers.connection_pool_for_spec @proxy_configuration[:primary]
+
+        @replica_pools = (@proxy_configuration[:replicas] || {}).map do |name, config_spec|
+          [name, Helpers.connection_pool_for_spec(config_spec)]
+        end.to_h
+
+        # Each thread gets its own `ProxyingConnectionPool`.
+        @reserved_proxies = Concurrent::Map.new
+
+        extend MonitorMixin
+      end
+
+      # Returns a list of *all* the connection pools owned by this handler.
+      def connection_pool_list
+        [@primary_pool] + @replica_pools.values
+      end
+
+      def establish_connection(owner, spec)
+        prefix = '[ActiveReplicas::Rails4::ConnectionHandler#establish_connection]'
+        ActiveRecord::Base.logger&.warn "#{prefix} Ignoring spec for #{owner.inspect}: #{spec.inspect}"
+        ActiveRecord::Base.logger&.info "#{prefix} Called from:\n" + Kernel.caller.first(5).map {|t| "  #{t}" }.join("\n")
+
+        current_proxy
+      end
+
+      def active_connections?
+        connection_pool_list.any?(&:active_connection?)
+      end
+
+      def clear_active_connections!
+        synchronize do
+          connection_pool_list.each(&:release_connection)
+          clear_current_proxy
+        end
+      end
+
+      def clear_reloadable_connections!
+        synchronize do
+          connection_pool_list.each(&:clear_reloadable_connections!)
+          clear_proxies!
+        end
+      end
+
+      def clear_all_connections!
+        synchronize do
+          connection_pool_list.each(&:disconnect!)
+          clear_proxies!
+        end
+      end
+
+      # Cribbed from:
+      #   https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L568
+      def retrieve_connection(klass)
+        pool = retrieve_connection_pool klass
+        raise ConnectionNotEstablished, "No connection pool for #{klass}" unless pool
+        conn = pool.connection
+        raise ConnectionNotEstablished, "No connection for #{klass} in connection pool" unless conn
+        conn
+      end
+
+      def connected?(klass)
+        pool = retrieve_connection_pool klass
+        pool && pool.connected?
+      end
+
+      def remove_connection(owner_klass)
+        if proxy = clear_current_proxy
+          proxy.automatic_reconnect = false
+          proxy.disconnect!
+          proxy.spec.config
+        end
+      end
+
+      def retrieve_connection_pool(klass)
+        current_proxy
+      end
+
+      # Semi-private implementation methdos
+      # ===================================
+
+      # Returns the `ThreadLocalConnectionHandler` for this thread.
+      def current_proxy
+        @reserved_proxies[current_thread_id] || synchronize do
+          @reserved_proxies[current_thread_id] ||= ProxyingConnectionPool.new(self)
+        end
+      end
+
+      # Remove the current reserved `ProxyingConnectionPool` from the pool.
+      def clear_current_proxy
+        @reserved_proxies.delete current_thread_id
+      end
+
+      # Clear all reserved `ProxyingConnectionPool` instances from the pool.
+      def clear_proxies!
+        @reserved_proxies.clear
+      end
+
+      def current_thread_id
+        Thread.current.object_id
+      end
+    end
+  end
+end

--- a/spec/active_replicas/proxying_connection_pool_spec.rb
+++ b/spec/active_replicas/proxying_connection_pool_spec.rb
@@ -6,24 +6,10 @@ describe ActiveReplicas::ProxyingConnectionPool do
   before do
     @primary_pool = double 'primary connection pool'
     @replica_pool = double 'replica connection pool'
+    @handler = double 'handler', primary_pool: @primary_pool,
+                                 replica_pools: { default0: @replica_pool }
 
-    allow(subject).to receive(:connection_pool_for_spec) do |spec|
-      case spec
-      when :primary then @primary_pool
-      when :replica then @replica_pool
-      else raise "Un-stubbed connection specification: #{spec}"
-      end
-    end
-
-    @subject = subject.new primary: :primary,
-                           replicas: { default0: :replica }
-  end
-
-  describe '#initialize' do
-    it 'sets up its primary and replica pools' do
-      expect(@subject.primary_pool).to eq @primary_pool
-      expect(@subject.replica_pools[:default0]).to eq @replica_pool
-    end
+    @subject = subject.new @handler
   end
 
   describe '#connection' do

--- a/spec/active_replicas/rails4/connection_handler_spec.rb
+++ b/spec/active_replicas/rails4/connection_handler_spec.rb
@@ -22,4 +22,24 @@ describe ActiveReplicas::Rails4::ConnectionHandler, if: is_rails4 do
       expect(config).to eq({ adapter: 'sqlite3', database: 'tmp/primary.sqlite3' })
     end
   end
+
+  describe '#initialize' do
+    before do
+      @primary_pool = double 'primary connection pool'
+      @replica_pool = double 'replica connection pool'
+
+      allow(ActiveReplicas::Rails4::Helpers).to receive(:connection_pool_for_spec) do |spec|
+        case spec
+        when :primary then @primary_pool
+        when :replica then @replica_pool
+        else raise "Un-stubbed connection specification: #{spec}"
+        end
+      end
+
+      @subject = subject.new proxy_configuration: {
+                               primary: :primary,
+                               replicas: { default0: :replica }
+                             }
+    end
+  end
 end


### PR DESCRIPTION
Adds a new intermediary class, `ProcessLocalConnectionHandler`, between the global connection handler and the proxying connection handler. This process-local handler manages creating the connection pools for the current process and provisioning individual proxying connection pools for each thread. Since each proxying pool is thread-local a change in the proxy state (ie. primary vs replica) in one thread will not change the proxy state in another thread.